### PR TITLE
Changing sprite prop to 'sprites' as an array

### DIFF
--- a/example/app/index.android.js
+++ b/example/app/index.android.js
@@ -54,7 +54,7 @@ export default class AnimatedSpriteExample extends Component {
       <View style={styles.container}>
         <AnimatedSprite
           ref={'monsterRef'}
-          sprite={monsterSprite}
+          sprites={monsterSprite.sprites}
           animationFrameIndex={monsterSprite.animationIndex(this.state.animationType)}
           loopAnimation={false}
           coordinates={{

--- a/example/app/sprites/monster/monsterSprite.js
+++ b/example/app/sprites/monster/monsterSprite.js
@@ -3,7 +3,7 @@ const monsterSprite = {
   name:"monster",
   size: {width: 220, height: 220},
   animationTypes: ['IDLE', 'WALK', 'EAT', 'CELEBRATE', 'DISGUST', 'ALL'],
-  frames: [
+  sprites: [
     require('./monster_idle.png'),
     require('./monster_walk01.png'),
     require('./monster_walk02.png'),
@@ -14,7 +14,7 @@ const monsterSprite = {
     require('./monster_celebrate02.png'),
     require('./monster_disgust01.png'),
   ],
-  animationIndex: function getAnimationIndex (animationType) {
+  animationIndex: function (animationType) {
     switch (animationType) {
       case 'IDLE':
         return [0];

--- a/example/rnas/index.android.js
+++ b/example/rnas/index.android.js
@@ -57,7 +57,7 @@ export default class rnas extends Component {
       <View style={styles.container}>
         <AnimatedSprite
           ref={'monsterRef'}
-          sprite={monsterSprite}
+          sprites={monsterSprite.sprites}
           animationFrameIndex={monsterSprite.animationIndex(this.state.animationType)}
           loopAnimation={false}
           coordinates={{

--- a/example/rnas/sprites/monster/monsterSprite.js
+++ b/example/rnas/sprites/monster/monsterSprite.js
@@ -3,7 +3,7 @@ const monsterSprite = {
   name:"monster",
   size: {width: 220, height: 220},
   animationTypes: ['IDLE', 'WALK', 'EAT', 'CELEBRATE', 'DISGUST', 'ALL'],
-  frames: [
+  sprites: [
     require('./monster_idle.png'),
     require('./monster_walk01.png'),
     require('./monster_walk02.png'),
@@ -14,7 +14,7 @@ const monsterSprite = {
     require('./monster_celebrate02.png'),
     require('./monster_disgust01.png'),
   ],
-  animationIndex: function getAnimationIndex (animationType) {
+  animationIndex: function (animationType) {
     switch (animationType) {
       case 'IDLE':
         return [0];

--- a/example/sprites/monster/monsterSprite.js
+++ b/example/sprites/monster/monsterSprite.js
@@ -3,7 +3,7 @@ const monsterSprite = {
   name:"monster",
   size: {width: 220, height: 220},
   animationTypes: ['IDLE', 'WALK', 'EAT', 'CELEBRATE', 'DISGUST', 'ALL'],
-  frames: [
+  sprites: [
     require('./monster_idle.png'),
     require('./monster_walk01.png'),
     require('./monster_walk02.png'),
@@ -14,7 +14,7 @@ const monsterSprite = {
     require('./monster_celebrate02.png'),
     require('./monster_disgust01.png'),
   ],
-  animationIndex: function getAnimationIndex (animationType) {
+  animationIndex: function (animationType) {
     switch (animationType) {
       case 'IDLE':
         return [0];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-animated-sprite",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "The React Native Animated Sprite package is a feature rich declaritive component for animation, tweening, and dragging sprites.",
   "main": "index.js",
   "scripts": {

--- a/src/components/AnimatedSprite.js
+++ b/src/components/AnimatedSprite.js
@@ -31,7 +31,6 @@ class AnimatedSprite extends React.Component {
       frameIndex: this.props.animationFrameIndex,
     };
 
-    this.sprite = this.props.sprite;
     this.frameIndex = 0;
     this.defaultAnimationInterval = undefined;
     this.fps = 8;
@@ -265,7 +264,7 @@ class AnimatedSprite extends React.Component {
           onPressIn={(evt) => this.handlePressIn(evt)}
           onPressOut={(evt) => this.handlePressOut(evt)}>
           <Image
-            source={this.sprite.frames[this.state.frameIndex]}
+            source={this.props.sprites[this.state.frameIndex]}
             style={{
               width: this.state.width,
               height: this.state.height,
@@ -278,7 +277,7 @@ class AnimatedSprite extends React.Component {
 }
 
 AnimatedSprite.propTypes = {
-  sprite: PropTypes.object.isRequired,
+  sprites: PropTypes.array.isRequired,
   coordinates: PropTypes.shape({
     top: PropTypes.number,
     left: PropTypes.number,
@@ -288,7 +287,6 @@ AnimatedSprite.propTypes = {
     height: PropTypes.number,
   }).isRequired,
   animationFrameIndex: PropTypes.array.isRequired,
-
   rotate: PropTypes.arrayOf(PropTypes.object),
   opacity: PropTypes.number,
   spriteUID: PropTypes.string,


### PR DESCRIPTION
I decided to change sprite prop of AnimatedSprite because it's only used as an object container of its own purpose of providing an array of sprites.

- In AnimatedSprite: renames 'sprite' property to 'sprites' as an array required
- In monsterSprite.js : renames attribute 'frames' to 'sprites'
- Updates all index.android.js using the modified AnimatedSprite 