### PR TITLE
Added fadeDuration 0 for disable fade on Android

### DIFF
--- a/src/components/AnimatedSprite.js
+++ b/src/components/AnimatedSprite.js
@@ -266,6 +266,7 @@ class AnimatedSprite extends React.Component {
           onPressOut={(evt) => this.handlePressOut(evt)}>
           <Image
             source={this.sprite.frames[this.state.frameIndex]}
+            fadeDuration={0}
             style={{
               width: this.state.width,
               height: this.state.height,


### PR DESCRIPTION
On Android devices images are loaded with fadeIn animation, by default with 300ms this affect the animated secuence.